### PR TITLE
Use RawGit CDN for demo JS file

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ function loadJS(src, cb) {
     script.onload = cb;
 }
 
-loadJS('https://raw.githubusercontent.com/zhuochun/monkey/master/src/monkey.js', function() {
+loadJS('https://cdn.rawgit.com/zhuochun/monkey/master/src/monkey.js', function() {
   var monkey = new Monkey().behaviour(new ClickBehaviour().getHandler()); monkey.play();
 });
 ```


### PR DESCRIPTION
Trying to load the JS file directly from Github will produce the following error:

```
Refused to execute script from 'https://raw.githubusercontent.com/zhuochun/monkey/master/src/monkey.js' because its MIME type ('text/plain') is not executable, and strict MIME type checking is enabled.
```

Changed to [RawGit's](https://rawgit.com/) version so that it works :smile: 
